### PR TITLE
feat: add Tufte-style sparkline charts for network dynamics

### DIFF
--- a/neural_plasticity/index.html
+++ b/neural_plasticity/index.html
@@ -219,6 +219,56 @@
             margin-top: 10px;
         }
 
+        .sparklines-panel {
+            background-color: var(--card-bg);
+            padding: 20px;
+            border-radius: 4px;
+            margin-top: 20px;
+        }
+
+        .sparklines-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 30px;
+        }
+
+        .sparkline-container {
+            position: relative;
+        }
+
+        .sparkline-label {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            color: var(--secondary-text);
+            margin-bottom: 8px;
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+
+        .sparkline-value {
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--accent-color);
+        }
+
+        .sparkline-canvas {
+            width: 100%;
+            height: 50px;
+            display: block;
+            background-color: #000000;
+            border: 1px solid #222;
+        }
+
+        .sparkline-range {
+            font-size: 9px;
+            color: #555;
+            margin-top: 4px;
+            display: flex;
+            justify-content: space-between;
+        }
+
         .neuron-grid {
             display: grid;
             grid-template-columns: repeat(auto-fill, 30px);
@@ -342,6 +392,44 @@
             <div class="stat">
                 <div class="stat-label">Time Steps</div>
                 <div class="stat-value" id="timeSteps">0</div>
+            </div>
+        </div>
+
+        <div class="sparklines-panel">
+            <div class="sparklines-grid">
+                <div class="sparkline-container">
+                    <div class="sparkline-label">
+                        <span>Network Activity</span>
+                        <span class="sparkline-value" id="activityValue">0</span>
+                    </div>
+                    <canvas id="activitySparkline" class="sparkline-canvas" width="600" height="50"></canvas>
+                    <div class="sparkline-range">
+                        <span id="activityMin">0</span>
+                        <span id="activityMax">25</span>
+                    </div>
+                </div>
+                <div class="sparkline-container">
+                    <div class="sparkline-label">
+                        <span>Average Synaptic Weight</span>
+                        <span class="sparkline-value" id="weightValue">0.50</span>
+                    </div>
+                    <canvas id="weightSparkline" class="sparkline-canvas" width="600" height="50"></canvas>
+                    <div class="sparkline-range">
+                        <span id="weightMin">0.0</span>
+                        <span id="weightMax">1.0</span>
+                    </div>
+                </div>
+                <div class="sparkline-container">
+                    <div class="sparkline-label">
+                        <span>Spike Rate (per 10 steps)</span>
+                        <span class="sparkline-value" id="spikeRateValue">0</span>
+                    </div>
+                    <canvas id="spikeRateSparkline" class="sparkline-canvas" width="600" height="50"></canvas>
+                    <div class="sparkline-range">
+                        <span id="spikeRateMin">0</span>
+                        <span id="spikeRateMax">250</span>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -497,6 +585,134 @@
             }
         }
 
+        // Sparkline Visualization (Tufte style)
+        class Sparkline {
+            constructor(canvas, maxDataPoints = 300, minValue = 0, maxValue = 1, color = '#ff3300') {
+                this.canvas = canvas;
+                this.ctx = canvas.getContext('2d');
+                this.data = [];
+                this.maxDataPoints = maxDataPoints;
+                this.minValue = minValue;
+                this.maxValue = maxValue;
+                this.color = color;
+                this.autoScale = false;
+            }
+
+            addData(value) {
+                this.data.push(value);
+                if (this.data.length > this.maxDataPoints) {
+                    this.data.shift();
+                }
+            }
+
+            clear() {
+                this.data = [];
+            }
+
+            draw() {
+                const ctx = this.ctx;
+                const width = this.canvas.width;
+                const height = this.canvas.height;
+
+                // Clear canvas
+                ctx.clearRect(0, 0, width, height);
+
+                if (this.data.length < 2) return;
+
+                // Determine range
+                let min = this.minValue;
+                let max = this.maxValue;
+                if (this.autoScale) {
+                    min = Math.min(...this.data);
+                    max = Math.max(...this.data);
+                    const range = max - min;
+                    if (range < 0.01) {
+                        min -= 0.5;
+                        max += 0.5;
+                    }
+                }
+                const range = max - min || 1;
+
+                // Draw subtle reference line at midpoint (Tufte style)
+                ctx.strokeStyle = '#222';
+                ctx.lineWidth = 0.5;
+                ctx.beginPath();
+                const midY = height / 2;
+                ctx.moveTo(0, midY);
+                ctx.lineTo(width, midY);
+                ctx.stroke();
+
+                // Draw filled area under line
+                ctx.fillStyle = this.color + '15'; // Very subtle fill
+                ctx.beginPath();
+                const startX = 0;
+                const startY = height - ((this.data[0] - min) / range) * height;
+                ctx.moveTo(startX, height);
+                ctx.lineTo(startX, startY);
+
+                for (let i = 0; i < this.data.length; i++) {
+                    const x = (i / (this.maxDataPoints - 1)) * width;
+                    const y = height - ((this.data[i] - min) / range) * height;
+                    ctx.lineTo(x, y);
+                }
+
+                const endX = ((this.data.length - 1) / (this.maxDataPoints - 1)) * width;
+                ctx.lineTo(endX, height);
+                ctx.closePath();
+                ctx.fill();
+
+                // Draw line (Tufte: thin, unobtrusive)
+                ctx.strokeStyle = this.color;
+                ctx.lineWidth = 1.5;
+                ctx.lineCap = 'round';
+                ctx.lineJoin = 'round';
+                ctx.beginPath();
+
+                for (let i = 0; i < this.data.length; i++) {
+                    const x = (i / (this.maxDataPoints - 1)) * width;
+                    const y = height - ((this.data[i] - min) / range) * height;
+
+                    if (i === 0) {
+                        ctx.moveTo(x, y);
+                    } else {
+                        ctx.lineTo(x, y);
+                    }
+                }
+
+                ctx.stroke();
+
+                // Draw endpoint dot (Tufte: emphasize current value)
+                if (this.data.length > 0) {
+                    const lastIdx = this.data.length - 1;
+                    const lastX = (lastIdx / (this.maxDataPoints - 1)) * width;
+                    const lastY = height - ((this.data[lastIdx] - min) / range) * height;
+
+                    ctx.fillStyle = this.color;
+                    ctx.beginPath();
+                    ctx.arc(lastX, lastY, 3, 0, Math.PI * 2);
+                    ctx.fill();
+
+                    // Subtle glow
+                    ctx.fillStyle = this.color + '40';
+                    ctx.beginPath();
+                    ctx.arc(lastX, lastY, 6, 0, Math.PI * 2);
+                    ctx.fill();
+                }
+            }
+
+            getCurrentValue() {
+                return this.data.length > 0 ? this.data[this.data.length - 1] : 0;
+            }
+
+            getMin() {
+                return this.data.length > 0 ? Math.min(...this.data) : this.minValue;
+            }
+
+            getMax() {
+                return this.data.length > 0 ? Math.max(...this.data) : this.maxValue;
+            }
+        }
+
         // Visualization
         class NetworkVisualizer {
             constructor(canvas, network) {
@@ -570,12 +786,28 @@
         const canvas = document.getElementById('networkCanvas');
         const visualizer = new NetworkVisualizer(canvas, network);
 
+        // Initialize sparklines
+        const activitySparkline = new Sparkline(
+            document.getElementById('activitySparkline'),
+            300, 0, NUM_NEURONS, '#00ff88'
+        );
+        const weightSparkline = new Sparkline(
+            document.getElementById('weightSparkline'),
+            300, 0, 1.0, '#ff3300'
+        );
+        const spikeRateSparkline = new Sparkline(
+            document.getElementById('spikeRateSparkline'),
+            300, 0, NUM_NEURONS * 10, '#ffaa00'
+        );
+
         let isRunning = true;
         let isHebbian = true;
         let learningRate = 0.05;
         let decayRate = 0.01;
         let threshold = 0.5;
         let spontaneousRate = 0.02;
+        let lastSpikeCount = 0;
+        let spikeWindow = [];
 
         // UI Elements
         const hebbianBtn = document.getElementById('hebbianBtn');
@@ -633,6 +865,11 @@
 
         resetBtn.addEventListener('click', () => {
             network.reset();
+            activitySparkline.clear();
+            weightSparkline.clear();
+            spikeRateSparkline.clear();
+            lastSpikeCount = 0;
+            spikeWindow = [];
         });
 
         stimulateRandomBtn.addEventListener('click', () => {
@@ -677,13 +914,48 @@
                 network.update(threshold, learningRate, isHebbian, decayRate, spontaneousRate);
 
                 // Update stats
-                activeNeuronsEl.textContent = network.getActiveNeurons();
-                avgWeightEl.textContent = network.getAverageWeight().toFixed(2);
+                const activeNeurons = network.getActiveNeurons();
+                const avgWeight = network.getAverageWeight();
+
+                activeNeuronsEl.textContent = activeNeurons;
+                avgWeightEl.textContent = avgWeight.toFixed(2);
                 totalSpikesEl.textContent = network.totalSpikes;
                 timeStepsEl.textContent = network.timeSteps;
+
+                // Update sparklines (sample every frame for smooth visualization)
+                activitySparkline.addData(activeNeurons);
+                weightSparkline.addData(avgWeight);
+
+                // Calculate spike rate (spikes in last 10 time steps)
+                const currentSpikes = network.totalSpikes - lastSpikeCount;
+                spikeWindow.push(currentSpikes);
+                if (spikeWindow.length > 10) {
+                    spikeWindow.shift();
+                }
+                const spikeRate = spikeWindow.reduce((a, b) => a + b, 0);
+                spikeRateSparkline.addData(spikeRate);
+                lastSpikeCount = network.totalSpikes;
+
+                // Update sparkline value displays
+                document.getElementById('activityValue').textContent = activeNeurons;
+                document.getElementById('weightValue').textContent = avgWeight.toFixed(3);
+                document.getElementById('spikeRateValue').textContent = spikeRate;
+
+                // Update sparkline range displays
+                document.getElementById('activityMin').textContent = activitySparkline.getMin().toFixed(0);
+                document.getElementById('activityMax').textContent = activitySparkline.getMax().toFixed(0);
+                document.getElementById('weightMin').textContent = weightSparkline.getMin().toFixed(2);
+                document.getElementById('weightMax').textContent = weightSparkline.getMax().toFixed(2);
+                document.getElementById('spikeRateMin').textContent = spikeRateSparkline.getMin().toFixed(0);
+                document.getElementById('spikeRateMax').textContent = spikeRateSparkline.getMax().toFixed(0);
             }
 
+            // Draw visualizations
             visualizer.draw();
+            activitySparkline.draw();
+            weightSparkline.draw();
+            spikeRateSparkline.draw();
+
             requestAnimationFrame(animate);
         }
 


### PR DESCRIPTION
- Add three minimalist sparkline visualizations tracking network metrics over time
- Network Activity: real-time count of active neurons
- Average Synaptic Weight: tracks plasticity changes (increases in Hebbian, decreases in anti-Hebbian)
- Spike Rate: rolling window of spikes per 10 timesteps
- Sparklines follow Edward Tufte's design principles:
  - Minimal chart-junk, no axes or grid
  - Thin, unobtrusive lines with subtle fills
  - Emphasized endpoints with dots
  - Data-dense display showing 300 timesteps
  - Dynamic range indicators (min/max)
- Auto-updating current values displayed inline with chart labels